### PR TITLE
issue _2

### DIFF
--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -135,11 +135,6 @@ extract_number <- function(number) {
   # Numbers not formatted will be returned as "unknown" and will need to 
   # be checked further.
   
-  # Uncomment code below to test function with check_area_code
-  # test <- c("608 555-3636", "+17143227807", "+12226666444", "222 343-6666", "alphabet", "6086185323")
-  # test
-  # map(test, extract_number) %>%  unlist()
-  
   # Can use function with following code:
   # logs$address_clean <- map(logs$address, extract_number)
   # logs <- logs %>% 
@@ -154,9 +149,9 @@ extract_number <- function(number) {
   if(!is.na(number)) {
     
     # exclude numbers with alphabetic characters from cleaning and
-    # return "unknown"
+    # return "not_formatted"
     if(str_detect(number, "[[:alpha:]]")) {
-      return("unknown")
+      return("not_formatted")
     }
     
     # Remove spaces, parentheses, and dashes 
@@ -203,19 +198,16 @@ extract_number <- function(number) {
       number_formatted <- number
     }
     
-    # set all formatted numbers to unknown
+    # set all formatted numbers to not_formatted
     if(is.null(number_formatted)) {
-      number_formatted <- "unknown"
+      number_formatted <- "not_formatted"
     }
     
     # check area codes
     if(!is.null(number_formatted)) {
-      if(number_formatted != "unknown" & nchar(number_formatted) == 10) {
+      if(number_formatted != "not_formatted" & nchar(number_formatted) == 10) {
       us_number <- check_area_code(number_formatted)
-
-        if(us_number == FALSE) {
-          number_formatted <- "Non-US number"
-        }
+      number_formatted <- ifelse(us_number == FALSE, "not_formatted", number_formatted)
       }
     }
     

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -151,14 +151,25 @@ extract_number <- function(number) {
   # Pattern - characters
   # e.g., email address, amber alert
   # checked and returned before removing spaces, dashes, etc
-  # REPLACE WITH NARROWER PATTERNS IN THE NEXT FEW CODE BLOCKS
-  if (str_detect(number, "[[:alpha:]]")) return(number)
-
-  # HANDLE Pattern to match email.  characters & @ and "." in the suffix after @
-
-  # HANDLE amber alert
   
+  # pattern - email.  characters & @ and "." in the suffix after @
+  if (str_detect(number, "^[[:alnum:]._-]+@[[:alnum:].-]+.[:alpha:]$")) {
+    return(number)
+  }
   
+  # pattern - amber alert/commercial mobile alert system - relevant only for SMS
+  # (?i) is case-insensitive modifier
+  if (str_detect(number, "#CMAS") || str_detect(number, "(?i)alert")) {
+    return(number)
+  }
+  
+  # return other numbers containing letters with warning that it did not match
+  # a pre-set pattern
+  if (str_detect(number, "[[:alpha:]]")) { 
+    warning (number, " did not match any pre-defined pattern")
+    return(number)
+  }
+
   # Now format before checking all other patterns
   # Remove spaces, parentheses, and dashes 
   if(str_detect(number, "[[:space:]-\\(\\)]")) {
@@ -167,7 +178,7 @@ extract_number <- function(number) {
   }
   
   # will copy number to formatted number to allow detection of multiple pattern matches.
-  # Not needed yet but may be when numbers can match both US $ Non-US numbers
+  # Not needed yet but may be when numbers can match both US & Non-US numbers
   formatted_number <- NULL 
   
   # Pattern - US numbers with +1 country code

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -196,7 +196,7 @@ extract_number <- function(number) {
   }
   
   
-  # Pattern 5 - US numbers with + but no country code
+  # Pattern - US numbers with + but no country code
   if (nchar(number) == 11 && str_detect(number, "^\\+") && check_area_code(str_sub(number, 2, 11))) {
     
     if(is.null(formatted_number)) {
@@ -206,7 +206,17 @@ extract_number <- function(number) {
     }
   }
   
-  # HANDLE 7 digit US numbers?
+  # Pattern - 7 digit US numbers with no area code
+  # This may eventually interact with non-US numbers?
+  # Can we get a list of all know US exchanges?
+  if (nchar(number) == 7) {
+    
+    if(is.null(formatted_number)) {
+      formatted_number <- number
+    } else {
+      stop(number, " matches multiple pre-defined patterns")
+    }
+  }
   
   # HANDLE *67, etc
   

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -223,8 +223,6 @@ extract_number <- function(number) {
     }
   }
   
-  # HANDLE *67
-  
   # pattern - N11 numbers (https://en.wikipedia.org/wiki/N11_code)
   # 211: Community services and information
   # 311: Municipal government services, non-emergency number
@@ -251,8 +249,23 @@ extract_number <- function(number) {
     }
   }
   
-  # HANDLE *69 - redial, *86 - voicemail for verizon phones,
+  # pattern - vertical service codes (https://en.wikipedia.org/wiki/Vertical_service_code)
   
+  
+  # pattern - *67 plus 10 digit phone number - blocks number
+  if (nchar(number) == 13 && str_detect(number, "\\*67") && check_area_code(str_sub(number, 4, 13))) {
+    if(is.null(formatted_number)) {
+      formatted_number <- str_remove(number, "\\*67")
+    } else {
+      stop(number, " matches multiple pre-defined patterns")
+  }
+  
+  # HANDLE - short codes (https://en.wikipedia.org/wiki/Short_code#United_States)
+  # Standard, interoperable short codes in the U.S. are five or six digits long,
+  # never start with 1, and only work in the U.S.
+  # JOHN - putting this as a temporary place holder to remind us to discuss 
+  # short codes.
+
   
   # generate warning if number did not match any format
   if (is.null(formatted_number)) {

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -151,9 +151,14 @@ extract_number <- function(number) {
   # Pattern - characters
   # e.g., email address, amber alert
   # checked and returned before removing spaces, dashes, etc
+  # REPLACE WITH NARROWER PATTERNS IN THE NEXT FEW CODE BLOCKS
   if (str_detect(number, "[[:alpha:]]")) return(number)
 
+  # HANDLE Pattern to match email.  characters & @ and "." in the suffix after @
 
+  # HANDLE amber alert
+  
+  
   # Now format before checking all other patterns
   # Remove spaces, parentheses, and dashes 
   if(str_detect(number, "[[:space:]-\\(\\)]")) {
@@ -176,7 +181,7 @@ extract_number <- function(number) {
   }
 
   # Pattern - 10 digit US numbers
-  if (nchar(number) == 10 && check_area_code(number)) {
+  if (nchar(number) == 10 && !str_detect(number, "\\+") && check_area_code(number)) {
     
     if(is.null(formatted_number)) {
       formatted_number <- number
@@ -218,8 +223,9 @@ extract_number <- function(number) {
     }
   }
   
-  # HANDLE *67, etc
+  # HANDLE *67
   
+  # HANDLE *69
   
   # generate warning if number did not match any format
   if (is.null(formatted_number)) {

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -250,7 +250,16 @@ extract_number <- function(number) {
   }
   
   # pattern - vertical service codes (https://en.wikipedia.org/wiki/Vertical_service_code)
-  
+  # JOHN - many of these may not be relevant for cell phones, I am only checking 
+  # for ones that seem likely to occur, but we can use the resource above if
+  # we see more slipping through.
+  if(number %in% c("*69", "*86", "*61", "*63", "*66", "*70", "*82")) {
+    if(is.null(formatted_number)) {
+      formatted_number <- number
+    } else {
+      stop(number, " matches multiple pre-defined patterns")
+    }   
+  }
   
   # pattern - *67 plus 10 digit phone number - blocks number
   if (nchar(number) == 13 && str_detect(number, "\\*67") && check_area_code(str_sub(number, 4, 13))) {
@@ -263,8 +272,11 @@ extract_number <- function(number) {
   # HANDLE - short codes (https://en.wikipedia.org/wiki/Short_code#United_States)
   # Standard, interoperable short codes in the U.S. are five or six digits long,
   # never start with 1, and only work in the U.S.
+  # I confirmed they also don't start with a 0 (min value = 20000)
   # JOHN - putting this as a temporary place holder to remind us to discuss 
-  # short codes.
+  # short codes. 
+    # pattern - (nchar(number) == 5 && str_detect(number, "[2-9][0-9]{4}")) || 
+    # (nchar(number) == 6 && str_detect(number, "[2-9][0-9]{5}"))
 
   
   # generate warning if number did not match any format

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -289,7 +289,13 @@ extract_number <- function(number) {
     # pattern - (nchar(number) == 5 && str_detect(number, "[2-9][0-9]{4}")) || 
     # (nchar(number) == 6 && str_detect(number, "[2-9][0-9]{5}"))
 
+    
+    
+  # HANDLE - group messages
+  # These show up in my android logs as multiple numbers separated by ~
   
+    
+      
   # generate warning if number did not match any format
   if (is.null(formatted_number)) {
     formatted_number <- number

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -278,6 +278,7 @@ extract_number <- function(number) {
       formatted_number <- str_remove(number, "\\*67")
     } else {
       stop(number, " matches multiple pre-defined patterns")
+    }
   }
   
   # HANDLE - short codes (https://en.wikipedia.org/wiki/Short_code#United_States)

--- a/fun_phone_numbers.R
+++ b/fun_phone_numbers.R
@@ -225,7 +225,34 @@ extract_number <- function(number) {
   
   # HANDLE *67
   
-  # HANDLE *69
+  # pattern - N11 numbers (https://en.wikipedia.org/wiki/N11_code)
+  # 211: Community services and information
+  # 311: Municipal government services, non-emergency number
+  # 411: Directory assistance
+  # 511: Traffic information or police non-emergency services
+  # 611: Telephone company (telco) customer service and repair
+  # 711: TDD and Relay Services for the deaf and hard of hearing
+  # 811: Underground public utility location
+  # 911: Emergency services (police, fire, ambulance and rescue services)
+  if (nchar(number) == 3 && str_detect(number, "[2-9]1{2}")) {
+    if(is.null(formatted_number)) {
+      formatted_number <- number
+    } else {
+      stop(number, " matches multiple pre-defined patterns")
+    }
+  }
+  
+  # pattern - 988 (National suicide hotline)
+  if (number == "988") {
+    if(is.null(formatted_number)) {
+      formatted_number <- number
+    } else {
+      stop(number, " matches multiple pre-defined patterns")
+    }
+  }
+  
+  # HANDLE *69 - redial, *86 - voicemail for verizon phones,
+  
   
   # generate warning if number did not match any format
   if (is.null(formatted_number)) {


### PR DESCRIPTION
Issue #2  - Updates function to return a 10 digit formatted US number. If the number is not 10 digits, contains text characters, or does not begin with a US or North American toll-free area code then "not_formatted" is returned. 

Test this function with the following code:
```
test <- c("608 555-3636", "+17143227807", "+12226666444", "222 343-6666", "alphabet", "6086185323")
test
map(test, extract_number) %>%  unlist()
```

@jjcurtin requesting a review of code and possibly simplifying code.